### PR TITLE
Change fillTemplate to use a map instead using a set of keys

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -48,6 +48,11 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.siddhi.extension.execution.map</groupId>
+            <artifactId>siddhi-execution-map</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/component/src/main/java/io/siddhi/extension/execution/string/FillTemplateFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/string/FillTemplateFunctionExtension.java
@@ -78,7 +78,7 @@ import static io.siddhi.query.api.definition.Attribute.Type.STRING;
                 type = DataType.STRING),
         examples =
         @Example(
-                syntax = "str:map(\"{{prize}} > 100 && {{salary}} < 10000\", " +
+                syntax = "str:fillTemplate(\"{{prize}} > 100 && {{salary}} < 10000\", " +
                         "map:create('prize', 300, 'salary', 10000))",
                 description = "" +
                         "In this example, the template is '{{prize}} > 100'." +
@@ -100,20 +100,20 @@ public class FillTemplateFunctionExtension extends FunctionExecutor {
 
         if (executorsCount != 2) {
             throw new SiddhiAppValidationException("Invalid number of arguments passed to "
-                    + "str:map() function. Required exactly 2, but found " + executorsCount);
+                    + "str:fillTemplate() function. Required exactly 2, but found " + executorsCount);
         }
         ExpressionExecutor executor1 = expressionExecutors[0];
         ExpressionExecutor executor2 = expressionExecutors[1];
 
         if (executor1.getReturnType() != STRING) {
             throw new SiddhiAppValidationException("Invalid parameter type found for the first argument of "
-                    + "str:map() function, required " + STRING.toString() + ", but found "
+                    + "str:fillTemplate() function, required " + STRING.toString() + ", but found "
                     + executor1.getReturnType().toString());
 
         }
         if (executor2.getReturnType() != OBJECT) {
             throw new SiddhiAppValidationException("Invalid parameter type found for the first argument of "
-                    + "str:map() function, required " + OBJECT.toString() + ", but found "
+                    + "str:fillTemplate() function, required " + OBJECT.toString() + ", but found "
                     + executor1.getReturnType().toString());
 
         }

--- a/component/src/main/java/io/siddhi/extension/execution/string/FillTemplateFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/string/FillTemplateFunctionExtension.java
@@ -150,39 +150,22 @@ public class FillTemplateFunctionExtension extends FunctionExecutor {
         int index;
         String key;
         StringBuilder stringBuilder = new StringBuilder();
-        if (isTemplateConstant) {
-            if (objects[1] instanceof Map) {
-                Map<String, Object> valueMap = (Map<String, Object>) objects[1];
-                for (int i = 1; i < templateSplitArray.length; i = i + 2) {
-                    key = templateSplitArray[i].trim();
-                    if (valueMap.get(key) != null) {
-                        templateSplitArray[i] = String.valueOf(valueMap.get(key));
-                    }
-                }
-            } else {
-                for (int i = 1; i < templateSplitArray.length; i = i + 2) {
-                    index = Integer.parseInt(templateSplitArray[i].trim());
-                    if (objects[index] != null) {
-                        templateSplitArray[i] = String.valueOf(objects[index]);
-                    }
+        if (!isTemplateConstant) {
+            templateSplitArray = sourceString.split(SPLIT_TEMPLATE);
+        }
+        if (objects[1] instanceof Map) {
+            Map<String, Object> valueMap = (Map<String, Object>) objects[1];
+            for (int i = 1; i < templateSplitArray.length; i = i + 2) {
+                key = templateSplitArray[i].trim();
+                if (valueMap.get(key) != null) {
+                    templateSplitArray[i] = String.valueOf(valueMap.get(key));
                 }
             }
         } else {
-            templateSplitArray = sourceString.split(SPLIT_TEMPLATE);
-            if (objects[1] instanceof Map) {
-                Map<String, Object> valueMap = (Map<String, Object>) objects[1];
-                for (int i = 1; i < templateSplitArray.length; i = i + 2) {
-                    key = templateSplitArray[i].trim();
-                    if (valueMap.get(key) != null) {
-                        templateSplitArray[i] = String.valueOf(valueMap.get(key));
-                    }
-                }
-            } else {
-                for (int i = 1; i < templateSplitArray.length; i = i + 2) {
-                    index = Integer.parseInt(templateSplitArray[i].trim());
-                    if (objects[index] != null) {
-                        templateSplitArray[i] = String.valueOf(objects[index]);
-                    }
+            for (int i = 1; i < templateSplitArray.length; i = i + 2) {
+                index = Integer.parseInt(templateSplitArray[i].trim());
+                if (objects[index] != null) {
+                    templateSplitArray[i] = String.valueOf(objects[index]);
                 }
             }
         }

--- a/component/src/test/java/io/siddhi/extension/execution/string/FillTemplateFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/string/FillTemplateFunctionExtensionTestCase.java
@@ -49,6 +49,114 @@ public class FillTemplateFunctionExtensionTestCase {
     public void testFillTemplate1() throws InterruptedException {
         LOGGER.info("FillTemplateFunctionExtension TestCase, where the arguments are valid strings");
         SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "define stream inputStream (template string, symbol string, volume string, " +
+                "price string);";
+
+        String template = "The stock price of {{1}}. Volume of {{1}} is {{3}} and the stock price is {{2}}";
+        String query = (
+                "@info(name = 'query1') from inputStream select " +
+                        "str:fillTemplate(template, symbol, price, volume) as msg " +
+                        "insert into outputStream;"
+        );
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
+
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    if (count.get() == 1) {
+                        AssertJUnit.assertEquals("The stock price of WSO2. Volume of WSO2 is 100 and the stock price " +
+                                "is " + "111.11", event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 2) {
+                        AssertJUnit.assertEquals("The stock price of IBM. Volume of IBM is 200 and the stock price " +
+                                "is " + "222.22", event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 3) {
+                        AssertJUnit.assertEquals("The stock price of GOOGLE. Volume of GOOGLE is 300 and the stock " +
+                                "price " +
+                                "is " + "333.33", event.getData(0));
+                        eventArrived = true;
+                    }
+                }
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+        inputHandler.send(new Object[]{template, "WSO2", "100", "111.11"});
+        inputHandler.send(new Object[]{template, "IBM", "200", "222.22"});
+        inputHandler.send(new Object[]{template, "GOOGLE", "300", "333.33"});
+        SiddhiTestHelper.waitForEvents(100, 3, count, 60000);
+        AssertJUnit.assertEquals(3, count.get());
+        AssertJUnit.assertTrue(eventArrived);
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testFillTemplate2() throws InterruptedException {
+        LOGGER.info("FillTemplateFunctionExtension TestCase, where the arguments are valid strings");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "define stream inputStream (template string, symbol string, volume long, " +
+                "price float);";
+
+        String template = "The stock price of {{1}}. Volume of {{1}} is {{3}} and the stock price is {{2}}";
+        String query = (
+                "@info(name = 'query1') from inputStream select " +
+                        "str:fillTemplate(template, symbol, price, volume) as msg " +
+                        "insert into outputStream;"
+        );
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
+
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    if (count.get() == 1) {
+                        AssertJUnit.assertEquals("The stock price of WSO2. Volume of WSO2 is 100 and the stock price " +
+                                "is " + "111.11", event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 2) {
+                        AssertJUnit.assertEquals("The stock price of IBM. Volume of IBM is 200 and the stock price " +
+                                "is " + "222.22", event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 3) {
+                        AssertJUnit.assertEquals("The stock price of GOOGLE. Volume of GOOGLE is 300 and the stock " +
+                                "price " +
+                                "is " + "333.33", event.getData(0));
+                        eventArrived = true;
+                    }
+                }
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+        inputHandler.send(new Object[]{template, "WSO2", 100L, 111.11f});
+        inputHandler.send(new Object[]{template, "IBM", 200L, 222.22f});
+        inputHandler.send(new Object[]{template, "GOOGLE", 300L, 333.33});
+        SiddhiTestHelper.waitForEvents(100, 3, count, 60000);
+        AssertJUnit.assertEquals(3, count.get());
+        AssertJUnit.assertTrue(eventArrived);
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testFillTemplate3() throws InterruptedException {
+        LOGGER.info("FillTemplateFunctionExtension TestCase, where the argument is a valid map");
+        SiddhiManager siddhiManager = new SiddhiManager();
         siddhiManager.setExtension("map:create", CreateFunctionExtension.class);
 
         String inStreamDefinition = "define stream inputStream (template string, symbol string, volume string, " +
@@ -103,8 +211,8 @@ public class FillTemplateFunctionExtensionTestCase {
     }
 
     @Test
-    public void testFillTemplate2() throws InterruptedException {
-        LOGGER.info("FillTemplateFunctionExtension TestCase, where the arguments are valid strings");
+    public void testFillTemplate4() throws InterruptedException {
+        LOGGER.info("FillTemplateFunctionExtension TestCase, where the argument is a valid map");
         SiddhiManager siddhiManager = new SiddhiManager();
 
         siddhiManager.setExtension("map:create", CreateFunctionExtension.class);
@@ -161,7 +269,7 @@ public class FillTemplateFunctionExtensionTestCase {
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class)
-    public void testFillTemplate3() throws InterruptedException {
+    public void testFillTemplate5() throws InterruptedException {
         LOGGER.info("FillTemplateFunctionExtension TestCase, where number of arguments are invalid");
         SiddhiManager siddhiManager = new SiddhiManager();
 
@@ -180,7 +288,7 @@ public class FillTemplateFunctionExtensionTestCase {
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class)
-    public void testFillTemplate4() throws InterruptedException {
+    public void testFillTemplate6() throws InterruptedException {
         LOGGER.info("FillTemplateFunctionExtension TestCase, the arguments types are invalid");
         SiddhiManager siddhiManager = new SiddhiManager();
 
@@ -190,8 +298,9 @@ public class FillTemplateFunctionExtensionTestCase {
                 "{{volume}} and the stock price is {{price}}";
         String query = (
                 "@info(name = 'query1') from inputStream select " +
-                        "str:fillTemplate(template, symbol) as msg " +
-                        "insert into outputStream;"
+                        "str:fillTemplate(template, " +
+                        "map:create('symbol', symbol, 'volume', volume, 'price', price), " +
+                        "symbol) as msg insert into outputStream;"
         );
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);

--- a/component/src/test/java/io/siddhi/extension/execution/string/FillTemplateFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/string/FillTemplateFunctionExtensionTestCase.java
@@ -309,4 +309,27 @@ public class FillTemplateFunctionExtensionTestCase {
         inputHandler.send(new Object[]{template, "WSO2", "100", "111.11"});
         siddhiAppRuntime.shutdown();
     }
+
+    @Test
+    public void testFillTemplate7() throws InterruptedException {
+        LOGGER.info("FillTemplateFunctionExtension TestCase, indexes in template are invalid");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "define stream inputStream (template string, symbol string, volume string, " +
+                "price string);";
+
+        String query = (
+                "@info(name = 'query1') from inputStream select " +
+                        "str:fillTemplate(template, symbol, price, volume) as msg " +
+                        "insert into outputStream;"
+        );
+
+        String template = "The stock price of {{1}}. Volume of {{1}} is {{4}} and the stock price is {{2}}";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+        inputHandler.send(new Object[]{template, "WSO2", "100", "111.11"});
+        siddhiAppRuntime.shutdown();
+    }
 }

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -41,6 +41,7 @@
             <class name="io.siddhi.extension.execution.string.UnhexFunctionExtensionTestCase" />
             <class name="io.siddhi.extension.execution.string.UpperFunctionExtensionTestCase" />
             <class name="io.siddhi.extension.execution.string.GroupConcatFunctionExtensionTestCase" />
+            <class name="io.siddhi.extension.execution.string.FillTemplateFunctionExtensionTestCase" />
         </classes>
     </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <siddhi.import.version.range>[5.0.0, 6.0.0)</siddhi.import.version.range>
+        <siddhi-extension-map.version>5.0.4</siddhi-extension-map.version>
     </properties>
 
     <scm>
@@ -74,6 +75,12 @@
                 <groupId>io.siddhi</groupId>
                 <artifactId>siddhi-query-api</artifactId>
                 <version>${siddhi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.siddhi.extension.execution.map</groupId>
+                <artifactId>siddhi-execution-map</artifactId>
+                <version>${siddhi-extension-map.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.log4j.wso2</groupId>


### PR DESCRIPTION
## Purpose
Resolve #61.

## Goals
Support key-value map template replacement in this extension.

## Approach
- Use a string and map instead of a set of strings.
- Find all entries `{{KEY}}` using a regular expression.
- Replace all KEYs with corresponding values.


## User stories
User can use this as follow.
 
### Input 
```sql
str:fillTemplate("{{prize}} > 100 && {{salary}} < 10000",  map:create('prize', 300, 'salary', 10000)))
```

### Output
```sql
300 > 100 && 10000 < 10000
```

## Release note
Update `str:fillTemplate(STRING, STRING, ...)` to `str:fillTemplate(STRING, MAP)`

## Automation tests
 - Unit tests 
   > Update the FillTemplateTests and add the test class to TestNG XML

## Test environment
Java version "1.8.0_201"
Java(TM) SE Runtime Environment (build 1.8.0_201-b09)
