### PR TITLE
Fix fillTemplate multiple issue happens when call multiple times

### DIFF
--- a/component/src/main/java/io/siddhi/extension/execution/string/FillTemplateFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/string/FillTemplateFunctionExtension.java
@@ -153,23 +153,24 @@ public class FillTemplateFunctionExtension extends FunctionExecutor {
         if (!isTemplateConstant) {
             templateSplitArray = sourceString.split(SPLIT_TEMPLATE);
         }
+        String[] templateSplitArrayClone = templateSplitArray.clone();
         if (objects[1] instanceof Map) {
             Map<String, Object> valueMap = (Map<String, Object>) objects[1];
-            for (int i = 1; i < templateSplitArray.length; i = i + 2) {
-                key = templateSplitArray[i].trim();
+            for (int i = 1; i < templateSplitArrayClone.length; i = i + 2) {
+                key = templateSplitArrayClone[i].trim();
                 if (valueMap.get(key) != null) {
-                    templateSplitArray[i] = String.valueOf(valueMap.get(key));
+                    templateSplitArrayClone[i] = String.valueOf(valueMap.get(key));
                 }
             }
         } else {
-            for (int i = 1; i < templateSplitArray.length; i = i + 2) {
-                index = Integer.parseInt(templateSplitArray[i].trim());
+            for (int i = 1; i < templateSplitArrayClone.length; i = i + 2) {
+                index = Integer.parseInt(templateSplitArrayClone[i].trim());
                 if (objects[index] != null) {
-                    templateSplitArray[i] = String.valueOf(objects[index]);
+                    templateSplitArrayClone[i] = String.valueOf(objects[index]);
                 }
             }
         }
-        for (String s: templateSplitArray) {
+        for (String s: templateSplitArrayClone) {
             stringBuilder.append(s);
         }
         return stringBuilder.toString();


### PR DESCRIPTION
## Purpose
Resolve https://github.com/siddhi-io/siddhi/issues/1526

## Approach
- Previously it split the string and replace the string with templated values to the array itself. So that when the second calls comes the templated values are already replaced in the references array.
- To fix as follow:
    - Clone of the templated array 
    - Replace values to the cloned array and return it

## Related PRs
https://github.com/siddhi-io/siddhi-execution-string/pull/62

## Test environment
Java version "1.8.0_201"
Java(TM) SE Runtime Environment (build 1.8.0_201-b09)